### PR TITLE
Fix repo url for npm page and cleanup package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,28 +2,17 @@
   "name": "auto-install",
   "version": "1.2.0",
   "description": "Auto installs dependencies as you code",
+  "keywords": "auto, dependencies, install, package, watch",
+  "repository": "siddharthkp/auto-install",
+  "license": "MIT",
   "main": "index.js",
+  "bin": "index.js",
+  "author": "siddharthkp",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type": "git",
-    "url": "github.com/siddharthkp/auto-install"
-  },
-  "keywords": [
-    "auto",
-    "install",
-    "dependencies",
-    "package",
-    "watch"
-  ],
-  "author": "siddharthkp",
-  "license": "MIT",
   "engines": {
     "node": ">= 4.4.5"
-  },
-  "bin": {
-    "auto-install": "./index.js"
   },
   "dependencies": {
     "chokidar": "1.6.0",


### PR DESCRIPTION
Hi!

This PR fixes the repo url for [the npm page](https://www.npmjs.com/package/auto-install) and cleanup package.json.
