### PR TITLE
Added --exact flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Secure mode: `auto-install --secure` Install popular modules only (> 10k downloa
 
 Modules in `.spec.js` and `.test.js` are added to `devDependencies`
 
+Exact mode: `auto-install --exact` similar to `npm install express --save-exact`
+
 #### Show your support
 
 :star: this repo

--- a/helpers.js
+++ b/helpers.js
@@ -7,6 +7,7 @@ const logSymbols = require('log-symbols');
 const request = require('request');
 const detective = require('detective');
 const colors = require('colors');
+const argv = require('yargs').argv;
 
 /* File reader
  * Return contents of given file
@@ -200,6 +201,8 @@ let installModule = ({name, dev}) => {
 
     if (dev) command += '-dev';
     if (dev) message += ' in devDependencies';
+
+    if (argv.exact) command += ' --save-exact';
 
     let success = runCommand(command);
     if (success) stopSpinner(spinner, message, 'green');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-install",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Auto installs dependencies as you code",
   "keywords": "auto, dependencies, install, package, watch",
   "homepage": "https://github.com/siddharthkp/auto-install#readme",


### PR DESCRIPTION
Usage: `auto-install --exact`

Similar to `npm install express --save-exact`
