### PR TITLE
Fix for @scope/modules being able to work (and spelling fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# WebStorm settings file
+.idea

--- a/helpers.js
+++ b/helpers.js
@@ -246,7 +246,10 @@ let removeLocalFiles = (modules) => modules.filter((module) => !module.name.incl
  */
 
 let removeFilePaths = (modules) => {
-    for (let module of modules) module.name = module.name.split('/')[0];
+    for (let module of modules) {
+        var slicedName = module.name.split('/')[0];
+        if (slicedName.substr(0,1) !== '@') module.name = slicedName;
+    }
     return modules;
 };
 

--- a/helpers.js
+++ b/helpers.js
@@ -247,8 +247,8 @@ let removeLocalFiles = (modules) => modules.filter((module) => !module.name.incl
 
 let removeFilePaths = (modules) => {
     for (let module of modules) {
-        var slicedName = module.name.split('/')[0];
-        if (slicedName.substr(0,1) !== '@') module.name = slicedName;
+        let slicedName = module.name.split('/')[0];
+        if (slicedName.substr(0, 1) !== '@') module.name = slicedName;
     }
     return modules;
 };

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ let initializeWatchers = () => {
 main = () => {
     if (!helpers.packageJSONExists()) {
         console.log(colors.red('package.json does not exist'));
-        console.log(colors.red('You can create on by using `npm init`'));
+        console.log(colors.red('You can create one by using `npm init`'));
         return;
     }
 


### PR DESCRIPTION
This prevents the `removeFilePaths` function from destroying @scope/modules.

The old logic thought the `@scope` _was_ the module as it was trimming off the end.

Also fixes 'You can create on' to 'You can create one'
