### PR TITLE
Added --trust-author flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-install",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Auto installs dependencies as you code",
   "keywords": "auto, dependencies, install, package, watch",
   "homepage": "https://github.com/siddharthkp/auto-install#readme",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "is-builtin-module": "1.0.0",
     "log-symbols": "1.0.2",
     "ora": "0.3.0",
+    "package-json": "2.3.3",
     "request": "2.74.0",
     "sync-exec": "0.6.2",
     "yargs": "4.8.1"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,6 +8,7 @@ const request = require('request');
 const detective = require('detective');
 const colors = require('colors');
 const argv = require('yargs').argv;
+const packageJson = require('package-json');
 
 /* File reader
  * Return contents of given file
@@ -209,6 +210,16 @@ let installModule = ({name, dev}) => {
     else stopSpinner(spinner, `${name} installation failed`, 'yellow');
 };
 
+/* Install module if author is trusted */
+
+let installModuleIfTrustedAuthor = ({name, dev}) => {
+    let trustedAuthor = argv['trust-author'];
+    packageJson(name).then(json => {
+        if (json.author && json.author.name === trustedAuthor) installModule({name, dev});
+        else console.log(colors.red(`${name} not trusted`));
+    });
+};
+
 /* Install module if trusted
  * Call isModulePopular before installing
  */
@@ -216,6 +227,7 @@ let installModule = ({name, dev}) => {
 let installModuleIfTrusted = ({name, dev}) => {
     isModulePopular(name, (popular) => {
         if (popular) installModule({name, dev});
+        else if (argv['trust-author']) installModuleIfTrustedAuthor({name, dev});
         else console.log(colors.red(`${name} not trusted`));
     });
 };


### PR DESCRIPTION
Works with the `--secure` flag, will install the module if the author is passed (even if the module is not popular enough to be secure)

Usage: `auto-install --secure --trust-author siddharthkp`

Closes https://github.com/siddharthkp/auto-install/issues/30
