### PR TITLE
Caching node_modules for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - "node"
   - "5"
   - "4"
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
As all the version in [package.json](https://github.com/siddharthkp/auto-install/blob/master/package.json#L21-L43) are locked. Caching `node_modules` will speed up tests 🚀 
