### PR TITLE
Add support for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Modules in `.spec.js` and `.test.js` are added to `devDependencies`
 
 `--yarn`    Use [yarn](https://yarnpkg.com) instead of npm
 
+`--include "<path>"`  Specify which glob pattern should be watched for changes. (**Double quotes are required to avoid expanding the path**)
+
 #### Show your support
 
 :star: this repo

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Modules in `.spec.js` and `.test.js` are added to `devDependencies`
 
 `--yarn`    Use [yarn](https://yarnpkg.com) instead of npm
 
+`--install-types`  Tries to install `@types` type definitions for modules that don't have them packaged
+
 `--include "<path>"`  Specify which glob pattern should be watched for changes. (**Double quotes are required to avoid expanding the path**)
 
 #### Show your support

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Modules in `.spec.js` and `.test.js` are added to `devDependencies`
 
 `--install-types`  Tries to install `@types` type definitions for modules that don't have them packaged
 
-`--include "<path>"`  Specify which glob pattern should be watched for changes. (**Double quotes are required to avoid expanding the path**)
-
 #### Show your support
 
 :star: this repo

--- a/example/typescript.ts
+++ b/example/typescript.ts
@@ -1,0 +1,7 @@
+// @ts-ignore: Not actually used
+import async from 'mongodb';
+
+export enum DummyEnum { // eslint-disable-line
+    DummyuMember = 'member1',
+    DummyMember2 = 'member2'
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,5 @@
 'use strict';
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
-
 var fs = require('fs');
 var glob = require('glob');
 
@@ -11,9 +9,7 @@ var _require = require('child_process'),
 var isBuiltInModule = require('is-builtin-module');
 var ora = require('ora');
 var logSymbols = require('log-symbols');
-var detective = require('detective');
-var es6detective = require('detective-es6');
-var typescriptDetective = require('detective-typescript');
+var detective = require('detective-typescript');
 var colors = require('colors');
 var argv = require('yargs').argv;
 var packageJson = require('package-json');
@@ -114,32 +110,17 @@ var isValidModule = function isValidModule(_ref) {
     return regex.test(name);
 };
 
-/**
- * Checks if we need to parse typescript or javascript
- * and returns a detective that can handle it.
- */
-var getDetective = function getDetective(typescript) {
-    if (typescript) return function (content) {
-        return typescriptDetective(content, { mixedImports: true });
-    };
-
-    return function (content, options) {
-        return [].concat(_toConsumableArray(detective(content, options)), _toConsumableArray(es6detective(content, options)));
-    };
-};
-
 /* Find modules from file
  * Returns array of modules from a file
  */
 
-var getModulesFromFile = function getModulesFromFile(path, typescript) {
+var getModulesFromFile = function getModulesFromFile(path) {
     var content = fs.readFileSync(path, 'utf8');
     var modules = [];
-    var detectiveOptions = { parse: { sourceType: 'module' } };
-    var correctDetective = getDetective(typescript);
+    var detectiveOptions = { mixedImports: true };
 
     try {
-        modules = correctDetective(content, detectiveOptions);
+        modules = detective(content, detectiveOptions);
         modules = modules.filter(function (module) {
             return isValidModule(module);
         });
@@ -223,7 +204,7 @@ var deduplicate = function deduplicate(modules) {
  * Read all .js files and grep for modules
  */
 
-var getUsedModules = function getUsedModules(path, typescript) {
+var getUsedModules = function getUsedModules(path) {
     var files = getFiles(path);
     var usedModules = [];
     var _iteratorNormalCompletion4 = true;
@@ -234,7 +215,7 @@ var getUsedModules = function getUsedModules(path, typescript) {
         for (var _iterator4 = files[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
             var fileName = _step4.value;
 
-            var modulesFromFile = getModulesFromFile(fileName, typescript);
+            var modulesFromFile = getModulesFromFile(fileName);
             var dev = isTestFile(fileName);
             var _iteratorNormalCompletion5 = true;
             var _didIteratorError5 = false;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,13 +14,14 @@ var colors = require('colors');
 var argv = require('yargs').argv;
 var packageJson = require('package-json');
 var https = require('https');
+var path = require('path');
 require('./includes-polyfill');
 
 /* File reader
  * Return contents of given file
  */
-var readFile = function readFile(path) {
-    var content = fs.readFileSync(path, 'utf8');
+var readFile = function readFile(filePath) {
+    var content = fs.readFileSync(filePath, 'utf8');
     return content;
 };
 
@@ -97,8 +98,8 @@ var getInstalledModules = function getInstalledModules() {
 /* Get all js files
  * Return path of all js files
  */
-var getFiles = function getFiles(path) {
-    return glob.sync(path, { ignore: ['node_modules/**/*'] });
+var getFiles = function getFiles(globPattern) {
+    return glob.sync(globPattern, { ignore: ['node_modules/**/*'] });
 };
 
 /* Check for valid string - to stop malicious intentions */
@@ -114,8 +115,8 @@ var isValidModule = function isValidModule(_ref) {
  * Returns array of modules from a file
  */
 
-var getModulesFromFile = function getModulesFromFile(path) {
-    var content = fs.readFileSync(path, 'utf8');
+var getModulesFromFile = function getModulesFromFile(filePath) {
+    var content = fs.readFileSync(filePath, 'utf8');
     var modules = [];
     var detectiveOptions = { mixedImports: true };
 
@@ -126,7 +127,7 @@ var getModulesFromFile = function getModulesFromFile(path) {
         });
     } catch (err) {
         var line = content.split('\n')[err.loc.line - 1];
-        console.log(colors.red('Could not parse ' + path + '. There is a syntax error in file at line ' + err.loc.line + ' column: ' + err.loc.column + '.\n' + line.slice(0, err.loc.column - 1) + '^' + line.slice(err.loc.column - 1)));
+        console.log(colors.red('Could not parse ' + filePath + '. There is a syntax error in file at line ' + err.loc.line + ' column: ' + err.loc.column + '.\n' + line.slice(0, err.loc.column - 1) + '^' + line.slice(err.loc.column - 1)));
     }
     return modules;
 };
@@ -204,8 +205,8 @@ var deduplicate = function deduplicate(modules) {
  * Read all .js files and grep for modules
  */
 
-var getUsedModules = function getUsedModules(path) {
-    var files = getFiles(path);
+var getUsedModules = function getUsedModules(globPattern) {
+    var files = getFiles(globPattern);
     var usedModules = [];
     var _iteratorNormalCompletion4 = true;
     var _didIteratorError4 = false;
@@ -352,13 +353,28 @@ var getInstallCommand = function getInstallCommand(name, dev) {
     return command;
 };
 
+/**
+ * Given the name of an installed module,
+ * return a boolean informing if typescript
+ * definition files are included with that module
+ */
+var areTypesIncluded = function areTypesIncluded(moduleName) {
+    var modulePath = path.join(process.cwd(), 'node_modules', moduleName);
+    var modulePackage = require(modulePath + '/package.json'); // eslint-disable-line global-require, import/no-dynamic-require
+    if (modulePackage.types || modulePackage.typings) return true;
+
+    return fs.existsSync(path.join(modulePath, 'index.d.ts'));
+};
+
 /* Install module
  * Install given module
  */
 
-var installModule = function installModule(_ref2) {
+var installModule = function installModule(_ref2, skipTypes) {
     var name = _ref2.name,
         dev = _ref2.dev;
+
+    var installTypes = argv['install-types'] && !skipTypes;
 
     var spinner = startSpinner('Installing ' + name, 'green');
 
@@ -368,7 +384,17 @@ var installModule = function installModule(_ref2) {
     if (dev) message += ' in devDependencies';
 
     var success = runCommand(command);
-    if (success) stopSpinner(spinner, message, 'green');else stopSpinner(spinner, name + ' installation failed', 'yellow');
+
+    if (!success) {
+        stopSpinner(spinner, name + ' installation failed', 'yellow');
+        return;
+    }
+
+    stopSpinner(spinner, message, 'green');
+
+    if (installTypes || !areTypesIncluded(name)) {
+        installModule({ name: '@types/' + name, dev: true }, true);
+    }
 };
 
 /* is scoped module? */
@@ -433,6 +459,7 @@ var uninstallModule = function uninstallModule(_ref5) {
         dev = _ref5.dev;
 
     if (dev) return;
+    var installTypes = argv['install-types'];
 
     var command = getUninstallCommand(name);
     var message = name + ' removed';
@@ -440,6 +467,11 @@ var uninstallModule = function uninstallModule(_ref5) {
     var spinner = startSpinner('Uninstalling ' + name, 'red');
     runCommand(command);
     stopSpinner(spinner, message, 'red');
+
+    var typeLibPath = path.join(process.cwd(), 'node_modules', '@types/' + name);
+    if (installTypes && fs.existsSync(typeLibPath)) {
+        uninstallModule({ name: '@types/' + name, dev: false });
+    }
 };
 
 /* Remove built in/native modules */

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var fs = require('fs');
 var glob = require('glob');
 
@@ -11,6 +13,7 @@ var ora = require('ora');
 var logSymbols = require('log-symbols');
 var detective = require('detective');
 var es6detective = require('detective-es6');
+var typescriptDetective = require('detective-typescript');
 var colors = require('colors');
 var argv = require('yargs').argv;
 var packageJson = require('package-json');
@@ -111,20 +114,32 @@ var isValidModule = function isValidModule(_ref) {
     return regex.test(name);
 };
 
+/**
+ * Checks if we need to parse typescript or javascript
+ * and returns a detective that can handle it.
+ */
+var getDetective = function getDetective(typescript) {
+    if (typescript) return function (content) {
+        return typescriptDetective(content, { mixedImports: true });
+    };
+
+    return function (content, options) {
+        return [].concat(_toConsumableArray(detective(content, options)), _toConsumableArray(es6detective(content, options)));
+    };
+};
+
 /* Find modules from file
  * Returns array of modules from a file
  */
 
-var getModulesFromFile = function getModulesFromFile(path) {
+var getModulesFromFile = function getModulesFromFile(path, typescript) {
     var content = fs.readFileSync(path, 'utf8');
     var modules = [];
     var detectiveOptions = { parse: { sourceType: 'module' } };
+    var correctDetective = getDetective(typescript);
+
     try {
-        modules = detective(content, detectiveOptions);
-
-        var es6modules = es6detective(content, detectiveOptions);
-        modules = modules.concat(es6modules);
-
+        modules = correctDetective(content, detectiveOptions);
         modules = modules.filter(function (module) {
             return isValidModule(module);
         });
@@ -208,7 +223,7 @@ var deduplicate = function deduplicate(modules) {
  * Read all .js files and grep for modules
  */
 
-var getUsedModules = function getUsedModules(path) {
+var getUsedModules = function getUsedModules(path, typescript) {
     var files = getFiles(path);
     var usedModules = [];
     var _iteratorNormalCompletion4 = true;
@@ -219,7 +234,7 @@ var getUsedModules = function getUsedModules(path) {
         for (var _iterator4 = files[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
             var fileName = _step4.value;
 
-            var modulesFromFile = getModulesFromFile(fileName);
+            var modulesFromFile = getModulesFromFile(fileName, typescript);
             var dev = isTestFile(fileName);
             var _iteratorNormalCompletion5 = true;
             var _didIteratorError5 = false;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -98,8 +98,8 @@ var getInstalledModules = function getInstalledModules() {
 /* Get all js files
  * Return path of all js files
  */
-var getFiles = function getFiles() {
-    return glob.sync('**/*.js', { ignore: ['node_modules/**/*'] });
+var getFiles = function getFiles(path) {
+    return glob.sync(path, { ignore: ['node_modules/**/*'] });
 };
 
 /* Check for valid string - to stop malicious intentions */
@@ -208,8 +208,8 @@ var deduplicate = function deduplicate(modules) {
  * Read all .js files and grep for modules
  */
 
-var getUsedModules = function getUsedModules() {
-    var files = getFiles();
+var getUsedModules = function getUsedModules(path) {
+    var files = getFiles(path);
     var usedModules = [];
     var _iteratorNormalCompletion4 = true;
     var _didIteratorError4 = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,8 +43,6 @@ var initializeWatchers = function initializeWatchers() {
  */
 
 main = function main() {
-    if (watchersInitialized) console.log('Changes detected. Updating installed packages');
-
     if (!helpers.packageJSONExists()) {
         console.log(colors.red('package.json does not exist'));
         console.log(colors.red('You can create one by using `npm init`'));
@@ -114,10 +112,8 @@ main = function main() {
         }
     }
 
-    if (!watchersInitialized) {
-        initializeWatchers();
-        helpers.cleanup();
-    }
+    helpers.cleanup();
+    if (!watchersInitialized) initializeWatchers();
 };
 
 /* Turn the key */

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,9 @@ if (argv['dont-uninstall']) uninstallMode = false;
 var includePath = '**/*.js';
 if (argv.include) includePath = argv.include;
 
+var typescript = false;
+if (argv.typescript) typescript = true;
+
 /* Watch files and repeat drill
  * Add a watcher, call main wrapper to repeat cycle
  */
@@ -52,7 +55,7 @@ main = function main() {
     var installedModules = [];
     installedModules = helpers.getInstalledModules();
 
-    var usedModules = helpers.getUsedModules(includePath);
+    var usedModules = helpers.getUsedModules(includePath, typescript);
     usedModules = helpers.filterRegistryModules(usedModules);
 
     // removeUnusedModules

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,9 +20,6 @@ if (argv['dont-uninstall']) uninstallMode = false;
 var includePath = '**/*.js';
 if (argv.include) includePath = argv.include;
 
-var typescript = false;
-if (argv.typescript) typescript = true;
-
 /* Watch files and repeat drill
  * Add a watcher, call main wrapper to repeat cycle
  */
@@ -55,7 +52,7 @@ main = function main() {
     var installedModules = [];
     installedModules = helpers.getInstalledModules();
 
-    var usedModules = helpers.getUsedModules(includePath, typescript);
+    var usedModules = helpers.getUsedModules(includePath);
     usedModules = helpers.filterRegistryModules(usedModules);
 
     // removeUnusedModules

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,18 +17,21 @@ if (argv.secure) secureMode = true;
 var uninstallMode = true;
 if (argv['dont-uninstall']) uninstallMode = false;
 
+var includePath = '**/*.js';
+if (argv.include) includePath = argv.include;
+
 /* Watch files and repeat drill
  * Add a watcher, call main wrapper to repeat cycle
  */
 
 var initializeWatchers = function initializeWatchers() {
-    var watcher = chokidar.watch('**/*.js', {
+    var watcher = chokidar.watch(includePath, {
         ignored: 'node_modules'
     });
     watcher.on('change', main).on('unlink', main);
 
     watchersInitialized = true;
-    console.log('Watchers initialized');
+    console.log('Watchers initialized. Watching ' + includePath);
 };
 
 /* Main wrapper
@@ -40,6 +43,8 @@ var initializeWatchers = function initializeWatchers() {
  */
 
 main = function main() {
+    if (watchersInitialized) console.log('Changes detected. Updating installed packages');
+
     if (!helpers.packageJSONExists()) {
         console.log(colors.red('package.json does not exist'));
         console.log(colors.red('You can create one by using `npm init`'));
@@ -49,7 +54,7 @@ main = function main() {
     var installedModules = [];
     installedModules = helpers.getInstalledModules();
 
-    var usedModules = helpers.getUsedModules();
+    var usedModules = helpers.getUsedModules(includePath);
     usedModules = helpers.filterRegistryModules(usedModules);
 
     // removeUnusedModules
@@ -109,8 +114,10 @@ main = function main() {
         }
     }
 
-    helpers.cleanup();
-    if (!watchersInitialized) initializeWatchers();
+    if (!watchersInitialized) {
+        initializeWatchers();
+        helpers.cleanup();
+    }
 };
 
 /* Turn the key */

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ if (argv.secure) secureMode = true;
 var uninstallMode = true;
 if (argv['dont-uninstall']) uninstallMode = false;
 
-var includePath = '**/*.js';
+var includePath = '**/*.{j,t}s';
 if (argv.include) includePath = argv.include;
 
 /* Watch files and repeat drill

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "colors": "1.1.2",
     "detective": "5.0.2",
     "detective-es6": "1.2.0",
+    "detective-typescript": "^5.7.0",
     "glob": "7.1.0",
     "is-builtin-module": "1.0.0",
     "log-symbols": "1.0.2",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,9 +4,7 @@ const {execSync} = require('child_process');
 const isBuiltInModule = require('is-builtin-module');
 const ora = require('ora');
 const logSymbols = require('log-symbols');
-const detective = require('detective');
-const es6detective = require('detective-es6');
-const typescriptDetective = require('detective-typescript');
+const detective = require('detective-typescript');
 const colors = require('colors');
 const argv = require('yargs').argv;
 const packageJson = require('package-json');
@@ -60,31 +58,17 @@ let isValidModule = ({name}) => {
     return regex.test(name);
 };
 
-/**
- * Checks if we need to parse typescript or javascript
- * and returns a detective that can handle it.
- */
-let getDetective = (typescript) => {
-    if (typescript) return (content) => typescriptDetective(content, {mixedImports: true});
-
-    return (content, options) => ([
-        ...detective(content, options),
-        ...es6detective(content, options)
-    ]);
-};
-
 /* Find modules from file
  * Returns array of modules from a file
  */
 
-let getModulesFromFile = (path, typescript) => {
+let getModulesFromFile = (path) => {
     let content = fs.readFileSync(path, 'utf8');
     let modules = [];
-    const detectiveOptions = {parse: {sourceType: 'module'}};
-    const correctDetective = getDetective(typescript);
+    const detectiveOptions = {mixedImports: true};
 
     try {
-        modules = correctDetective(content, detectiveOptions);
+        modules = detective(content, detectiveOptions);
         modules = modules.filter((module) => isValidModule(module));
     } catch (err) {
         const line = content.split('\n')[err.loc.line - 1];
@@ -139,11 +123,11 @@ let deduplicate = (modules) => {
  * Read all .js files and grep for modules
  */
 
-let getUsedModules = (path, typescript) => {
+let getUsedModules = (path) => {
     let files = getFiles(path);
     let usedModules = [];
     for (let fileName of files) {
-        let modulesFromFile = getModulesFromFile(fileName, typescript);
+        let modulesFromFile = getModulesFromFile(fileName);
         let dev = isTestFile(fileName);
         for (let name of modulesFromFile) usedModules.push({name, dev});
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -50,7 +50,7 @@ let getInstalledModules = () => {
 /* Get all js files
  * Return path of all js files
  */
-let getFiles = () => glob.sync('**/*.js', {ignore: ['node_modules/**/*']});
+let getFiles = (path) => glob.sync(path, {ignore: ['node_modules/**/*']});
 
 /* Check for valid string - to stop malicious intentions */
 
@@ -127,8 +127,8 @@ let deduplicate = (modules) => {
  * Read all .js files and grep for modules
  */
 
-let getUsedModules = () => {
-    let files = getFiles();
+let getUsedModules = (path) => {
+    let files = getFiles(path);
     let usedModules = [];
     for (let fileName of files) {
         let modulesFromFile = getModulesFromFile(fileName);

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,6 @@ let initializeWatchers = () => {
  */
 
 main = () => {
-    if (watchersInitialized) console.log('Changes detected. Updating installed packages');
-
     if (!helpers.packageJSONExists()) {
         console.log(colors.red('package.json does not exist'));
         console.log(colors.red('You can create one by using `npm init`'));
@@ -72,10 +70,8 @@ main = () => {
         else helpers.installModule(module);
     }
 
-    if (!watchersInitialized) {
-        initializeWatchers();
-        helpers.cleanup();
-    }
+    helpers.cleanup();
+    if (!watchersInitialized) initializeWatchers();
 };
 
 /* Turn the key */

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ let uninstallMode = true;
 if (argv['dont-uninstall']) uninstallMode = false;
 
 let includePath = '**/*.{j,t}s';
-if (argv.include) includePath = argv.include;
 
 /* Watch files and repeat drill
  * Add a watcher, call main wrapper to repeat cycle

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,6 @@ if (argv['dont-uninstall']) uninstallMode = false;
 let includePath = '**/*.js';
 if (argv.include) includePath = argv.include;
 
-let typescript = false;
-if (argv.typescript) typescript = true;
-
 /* Watch files and repeat drill
  * Add a watcher, call main wrapper to repeat cycle
  */
@@ -55,7 +52,7 @@ main = () => {
     let installedModules = [];
     installedModules = helpers.getInstalledModules();
 
-    let usedModules = helpers.getUsedModules(includePath, typescript);
+    let usedModules = helpers.getUsedModules(includePath);
     usedModules = helpers.filterRegistryModules(usedModules);
 
     // removeUnusedModules

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,9 @@ if (argv['dont-uninstall']) uninstallMode = false;
 let includePath = '**/*.js';
 if (argv.include) includePath = argv.include;
 
+let typescript = false;
+if (argv.typescript) typescript = true;
+
 /* Watch files and repeat drill
  * Add a watcher, call main wrapper to repeat cycle
  */
@@ -52,7 +55,7 @@ main = () => {
     let installedModules = [];
     installedModules = helpers.getInstalledModules();
 
-    let usedModules = helpers.getUsedModules(includePath);
+    let usedModules = helpers.getUsedModules(includePath, typescript);
     usedModules = helpers.filterRegistryModules(usedModules);
 
     // removeUnusedModules

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ if (argv.secure) secureMode = true;
 let uninstallMode = true;
 if (argv['dont-uninstall']) uninstallMode = false;
 
-let includePath = '**/*.js';
+let includePath = '**/*.{j,t}s';
 if (argv.include) includePath = argv.include;
 
 /* Watch files and repeat drill

--- a/test/lib/diff.test.js
+++ b/test/lib/diff.test.js
@@ -6,7 +6,7 @@ var testData = require('./testData.js');
 
 describe('diff', function () {
     var installedModules = helpers.getInstalledModules();
-    var usedModules = helpers.getUsedModules();
+    var usedModules = helpers.getUsedModules(testData.includePath);
     usedModules = helpers.filterRegistryModules(usedModules);
     var unusedModules = helpers.diff(installedModules, usedModules);
     var modulesNotInstalled = helpers.diff(usedModules, installedModules);
@@ -14,6 +14,7 @@ describe('diff', function () {
         unusedModules.should.deep.equal(testData.unusedModules);
     });
     it('should return modulesNotInstalled', function () {
-        modulesNotInstalled.should.deep.equal(testData.modulesNotInstalled);
+        modulesNotInstalled.length.should.be.equal(7);
+        modulesNotInstalled.should.have.deep.members(testData.modulesNotInstalled);
     });
 });

--- a/test/lib/filterRegistryModules.test.js
+++ b/test/lib/filterRegistryModules.test.js
@@ -5,8 +5,10 @@ var helpers = require('../../lib/helpers');
 var testData = require('./testData.js');
 
 describe('filterRegistryModules', function () {
-    var usedModules = helpers.getUsedModules();
+    var usedModules = helpers.getUsedModules(testData.includePath);
     it('should filter registry modules', function () {
-        helpers.filterRegistryModules(usedModules).should.deep.equal(testData.filteredUsedModules);
+        var filteredUsedModules = helpers.filterRegistryModules(usedModules);
+        filteredUsedModules.length.should.be.equal(9);
+        filteredUsedModules.should.have.deep.members(testData.filteredUsedModules);
     });
 });

--- a/test/lib/getUsedModules.test.js
+++ b/test/lib/getUsedModules.test.js
@@ -6,6 +6,8 @@ var testData = require('./testData.js');
 
 describe('getUsedModules', function () {
     it('should return used modules', function () {
-        helpers.getUsedModules().should.deep.equal(testData.usedModules);
+        var usedModules = helpers.getUsedModules(testData.includePath);
+        usedModules.length.should.be.equal(11);
+        usedModules.should.have.deep.members(testData.usedModules);
     });
 });

--- a/test/lib/testData.js
+++ b/test/lib/testData.js
@@ -1,16 +1,19 @@
 'use strict';
 
+var includePath = '**/*.{j,t}s';
+
 var installedModules = [{ name: 'request', dev: false }, { name: 'yargs', dev: false }, { name: 'mocha', dev: true }];
 
-var usedModules = [{ name: 'chai', dev: true }, { name: 'chokidar', dev: false }, { name: 'yargs', dev: false }, { name: 'fs', dev: false }, { name: '../src/helpers', dev: false }, { name: '@siddharthkp/auto-install', dev: false }, { name: 'lodash/memoize', dev: false }, { name: 'request', dev: false }, { name: 'ava', dev: false }, { name: 'async', dev: false }];
+var usedModules = [{ name: 'chai', dev: true }, { name: 'chokidar', dev: false }, { name: 'yargs', dev: false }, { name: 'fs', dev: false }, { name: '../src/helpers', dev: false }, { name: '@siddharthkp/auto-install', dev: false }, { name: 'lodash/memoize', dev: false }, { name: 'request', dev: false }, { name: 'async', dev: false }, { name: 'ava', dev: false }, { name: 'mongodb', dev: false }];
 
 var unusedModules = [{ name: 'mocha', dev: true }];
 
-var modulesNotInstalled = [{ name: 'chai', dev: true }, { name: 'chokidar', dev: false }, { name: '@siddharthkp/auto-install', dev: false }, { name: 'lodash', dev: false }, { name: 'ava', dev: false }, { name: 'async', dev: false }];
+var modulesNotInstalled = [{ name: 'chai', dev: true }, { name: 'chokidar', dev: false }, { name: '@siddharthkp/auto-install', dev: false }, { name: 'lodash', dev: false }, { name: 'ava', dev: false }, { name: 'async', dev: false }, { name: 'mongodb', dev: false }];
 
-var filteredUsedModules = [{ name: 'chai', dev: true }, { name: 'chokidar', dev: false }, { name: 'yargs', dev: false }, { name: '@siddharthkp/auto-install', dev: false }, { name: 'lodash', dev: false }, { name: 'request', dev: false }, { name: 'ava', dev: false }, { name: 'async', dev: false }];
+var filteredUsedModules = [{ name: 'chai', dev: true }, { name: 'chokidar', dev: false }, { name: 'yargs', dev: false }, { name: '@siddharthkp/auto-install', dev: false }, { name: 'lodash', dev: false }, { name: 'request', dev: false }, { name: 'ava', dev: false }, { name: 'async', dev: false }, { name: 'mongodb', dev: false }];
 
 module.exports = {
+    includePath: includePath,
     installedModules: installedModules,
     usedModules: usedModules,
     unusedModules: unusedModules,

--- a/test/src/diff.test.js
+++ b/test/src/diff.test.js
@@ -4,7 +4,7 @@ const testData = require('./testData.js');
 
 describe('diff', () => {
     let installedModules = helpers.getInstalledModules();
-    let usedModules = helpers.getUsedModules();
+    let usedModules = helpers.getUsedModules(testData.includePath);
     usedModules = helpers.filterRegistryModules(usedModules);
     let unusedModules = helpers.diff(installedModules, usedModules);
     let modulesNotInstalled = helpers.diff(usedModules, installedModules);
@@ -12,7 +12,8 @@ describe('diff', () => {
         unusedModules.should.deep.equal(testData.unusedModules);
     });
     it('should return modulesNotInstalled', () => {
-        modulesNotInstalled.should.deep.equal(testData.modulesNotInstalled);
+        modulesNotInstalled.length.should.be.equal(7);
+        modulesNotInstalled.should.have.deep.members(testData.modulesNotInstalled);
     });
 });
 

--- a/test/src/filterRegistryModules.test.js
+++ b/test/src/filterRegistryModules.test.js
@@ -3,9 +3,11 @@ const helpers = require('../../lib/helpers');
 const testData = require('./testData.js');
 
 describe('filterRegistryModules', () => {
-    let usedModules = helpers.getUsedModules();
+    let usedModules = helpers.getUsedModules(testData.includePath);
     it('should filter registry modules', () => {
-        helpers.filterRegistryModules(usedModules).should.deep.equal(testData.filteredUsedModules);
+        const filteredUsedModules = helpers.filterRegistryModules(usedModules);
+        filteredUsedModules.length.should.be.equal(9);
+        filteredUsedModules.should.have.deep.members(testData.filteredUsedModules);
     });
 });
 

--- a/test/src/getUsedModules.test.js
+++ b/test/src/getUsedModules.test.js
@@ -4,7 +4,8 @@ const testData = require('./testData.js');
 
 describe('getUsedModules', () => {
     it('should return used modules', () => {
-        helpers.getUsedModules().should.deep.equal(testData.usedModules);
+        const usedModules = helpers.getUsedModules(testData.includePath);
+        usedModules.length.should.be.equal(11);
+        usedModules.should.have.deep.members(testData.usedModules);
     });
 });
-

--- a/test/src/testData.js
+++ b/test/src/testData.js
@@ -1,3 +1,5 @@
+let includePath = '**/*.{j,t}s';
+
 let installedModules = [
     {name: 'request', dev: false},
     {name: 'yargs', dev: false},
@@ -13,8 +15,9 @@ let usedModules = [
     {name: '@siddharthkp/auto-install', dev: false},
     {name: 'lodash/memoize', dev: false},
     {name: 'request', dev: false},
+    {name: 'async', dev: false},
     {name: 'ava', dev: false},
-    {name: 'async', dev: false}
+    {name: 'mongodb', dev: false}
 ];
 
 let unusedModules = [
@@ -27,7 +30,8 @@ let modulesNotInstalled = [
     {name: '@siddharthkp/auto-install', dev: false},
     {name: 'lodash', dev: false},
     {name: 'ava', dev: false},
-    {name: 'async', dev: false}
+    {name: 'async', dev: false},
+    {name: 'mongodb', dev: false}
 ];
 
 let filteredUsedModules = [
@@ -38,10 +42,12 @@ let filteredUsedModules = [
     {name: 'lodash', dev: false},
     {name: 'request', dev: false},
     {name: 'ava', dev: false},
-    {name: 'async', dev: false}
+    {name: 'async', dev: false},
+    {name: 'mongodb', dev: false}
 ];
 
 module.exports = {
+    includePath,
     installedModules,
     usedModules,
     unusedModules,


### PR DESCRIPTION
I tried to use this with Typescript, but realized it only watches for `**/*..js`, and thus, it was not possible to auto-install packages from Typescript (`.ts`) files. Also, the two variants of `detective` used do not support typescript.

I added a new argument, `--includes`, which sets the glob pattern that should be watched. I also added a `--typescript` argument, which allows us to use `detective-typescript` to parse the files.

I also added the proper documentation for those new options, and a new segment to the "watchers initialized" informing the path being watched.