### PR TITLE
Updated link to npm weekly #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Auto installs dependencies as you code. Just hit save.
 
 ![Auto installs dependencies as you code](https://raw.githubusercontent.com/siddharthkp/auto-install/master/demo.gif)
 
-Featured in [npm weekly #56](http://us9.campaign-archive2.com/?u=077dfd41302a71310cef619e5&id=9e020606f1)!
+Featured in [npm weekly #56](https://medium.com/npm-inc/npm-weekly-56-npm-on-javascript-air-the-cli-team-changes-cadence-and-easier-dependency-f7e4cc24d053)!
 
 #### Install
 


### PR DESCRIPTION
Link to NPM Weekly #56 is broken. Maybe link is not valid now.
Linked to new link.